### PR TITLE
refactor: add ERC6909 primitive and minimal storage layout

### DIFF
--- a/src/facets/token/ERC6909/ERC6909.sol
+++ b/src/facets/token/ERC6909/ERC6909.sol
@@ -45,7 +45,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
 
   /// @inheritdoc IERC6909
   function totalSupply(uint256 id) public view virtual returns (uint256) {
-    return ERC6909Storage.getLayout().inner.totalSupply(id);
+    return ERC6909Storage.getLayout().totalSupply(id);
   }
 
   /// @inheritdoc IERC6909
@@ -53,7 +53,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     address owner,
     uint256 id
   ) public view virtual returns (uint256) {
-    return ERC6909Storage.getLayout().inner.balanceOf(owner, id);
+    return ERC6909Storage.getLayout().balanceOf(owner, id);
   }
 
   /// @inheritdoc IERC6909
@@ -62,7 +62,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     address spender,
     uint256 id
   ) public view virtual returns (uint256) {
-    return ERC6909Storage.getLayout().inner.allowance(owner, spender, id);
+    return ERC6909Storage.getLayout().allowance(owner, spender, id);
   }
 
   /// @inheritdoc IERC6909
@@ -70,7 +70,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     address owner,
     address spender
   ) public view virtual returns (bool) {
-    return ERC6909Storage.getLayout().inner.isOperator(owner, spender);
+    return ERC6909Storage.getLayout().isOperator(owner, spender);
   }
 
   /// @inheritdoc IERC6909
@@ -79,7 +79,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    ERC6909Storage.getLayout().inner.transfer(to, id, amount);
+    ERC6909Storage.getLayout().transfer(to, id, amount);
     emit Transfer(msg.sender, msg.sender, to, id, amount);
     return true;
   }
@@ -91,7 +91,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    ERC6909Storage.getLayout().inner.transferFrom(from, to, id, amount);
+    ERC6909Storage.getLayout().transferFrom(from, to, id, amount);
     emit Transfer(msg.sender, from, to, id, amount);
     return true;
   }
@@ -102,7 +102,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    ERC6909Storage.getLayout().inner.approve(spender, id, amount);
+    ERC6909Storage.getLayout().approve(spender, id, amount);
     emit Approval(msg.sender, spender, id, amount);
     return true;
   }
@@ -112,7 +112,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     address operator,
     bool approved
   ) external returns (bool) {
-    ERC6909Storage.getLayout().inner.setOperator(operator, approved);
+    ERC6909Storage.getLayout().setOperator(operator, approved);
     emit OperatorSet(msg.sender, operator, approved);
     return true;
   }
@@ -122,12 +122,12 @@ abstract contract ERC6909 is Facet, IERC6909 {
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
   function _mint(address to, uint256 id, uint256 amount) internal virtual {
-    ERC6909Storage.getLayout().inner.mint(to, id, amount);
+    ERC6909Storage.getLayout().mint(to, id, amount);
     emit Transfer(msg.sender, address(0), to, id, amount);
   }
 
   function _burn(address from, uint256 id, uint256 amount) internal virtual {
-    ERC6909Storage.getLayout().inner.burn(from, id, amount);
+    ERC6909Storage.getLayout().burn(from, id, amount);
     emit Transfer(msg.sender, from, address(0), id, amount);
   }
 }

--- a/src/facets/token/ERC6909/ERC6909.sol
+++ b/src/facets/token/ERC6909/ERC6909.sol
@@ -5,7 +5,8 @@ pragma solidity ^0.8.23;
 import {IERC6909} from "./IERC6909.sol";
 
 // libraries
-import {ERC6909Lib} from "./ERC6909Lib.sol";
+import {MinimalERC6909Storage} from "../../../primitive/ERC6909.sol";
+import {ERC6909Storage} from "./ERC6909Storage.sol";
 
 // contracts
 import {Facet} from "../../Facet.sol";
@@ -14,6 +15,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
   /*                      ERC6909 METADATA                      */
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
   function __ERC6909_init() internal {
     _addInterface(0x0f632fb3);
   }
@@ -44,15 +46,15 @@ abstract contract ERC6909 is Facet, IERC6909 {
 
   /// @inheritdoc IERC6909
   function totalSupply(uint256 id) public view virtual returns (uint256) {
-    return ERC6909Lib.totalSupply(id);
+    return ERC6909Storage.getLayout().inner.totalSupply(id);
   }
 
   /// @inheritdoc IERC6909
   function balanceOf(
     address owner,
     uint256 id
-  ) public view virtual returns (uint256 balance) {
-    return ERC6909Lib.balanceOf(owner, id);
+  ) public view virtual returns (uint256) {
+    return ERC6909Storage.getLayout().inner.balanceOf(owner, id);
   }
 
   /// @inheritdoc IERC6909
@@ -60,16 +62,16 @@ abstract contract ERC6909 is Facet, IERC6909 {
     address owner,
     address spender,
     uint256 id
-  ) public view virtual returns (uint256 remaining) {
-    return ERC6909Lib.allowance(owner, spender, id);
+  ) public view virtual returns (uint256) {
+    return ERC6909Storage.getLayout().inner.allowance(owner, spender, id);
   }
 
   /// @inheritdoc IERC6909
   function isOperator(
     address owner,
     address spender
-  ) public view virtual returns (bool status) {
-    return ERC6909Lib.isOperator(owner, spender);
+  ) public view virtual returns (bool) {
+    return ERC6909Storage.getLayout().inner.isOperator(owner, spender);
   }
 
   /// @inheritdoc IERC6909
@@ -78,7 +80,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    return ERC6909Lib.transfer(to, id, amount);
+    return ERC6909Storage.getLayout().inner.transfer(to, id, amount);
   }
 
   /// @inheritdoc IERC6909
@@ -88,7 +90,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    return ERC6909Lib.transferFrom(from, to, id, amount);
+    return ERC6909Storage.getLayout().inner.transferFrom(from, to, id, amount);
   }
 
   /// @inheritdoc IERC6909
@@ -97,7 +99,7 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    return ERC6909Lib.approve(spender, id, amount);
+    return ERC6909Storage.getLayout().inner.approve(spender, id, amount);
   }
 
   /// @inheritdoc IERC6909
@@ -105,17 +107,18 @@ abstract contract ERC6909 is Facet, IERC6909 {
     address operator,
     bool approved
   ) external returns (bool) {
-    return ERC6909Lib.setOperator(operator, approved);
+    return ERC6909Storage.getLayout().inner.setOperator(operator, approved);
   }
 
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
   /*                           MINTING                          */
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
   function _mint(address to, uint256 id, uint256 amount) internal virtual {
-    return ERC6909Lib.mint(to, id, amount);
+    return ERC6909Storage.getLayout().inner.mint(to, id, amount);
   }
 
   function _burn(address from, uint256 id, uint256 amount) internal virtual {
-    return ERC6909Lib.burn(from, id, amount);
+    return ERC6909Storage.getLayout().inner.burn(from, id, amount);
   }
 }

--- a/src/facets/token/ERC6909/ERC6909.sol
+++ b/src/facets/token/ERC6909/ERC6909.sol
@@ -6,11 +6,14 @@ import {IERC6909} from "./IERC6909.sol";
 
 // libraries
 import {ERC6909Storage} from "./ERC6909Storage.sol";
+import {ERC6909Lib} from "src/primitive/ERC6909.sol";
 
 // contracts
 import {Facet} from "../../Facet.sol";
 
 abstract contract ERC6909 is Facet, IERC6909 {
+  using ERC6909Lib for ERC6909Lib.MinimalERC6909Storage;
+
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
   /*                      ERC6909 METADATA                      */
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/src/facets/token/ERC6909/ERC6909.sol
+++ b/src/facets/token/ERC6909/ERC6909.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.23;
 import {IERC6909} from "./IERC6909.sol";
 
 // libraries
-import {MinimalERC6909Storage} from "../../../primitive/ERC6909.sol";
 import {ERC6909Storage} from "./ERC6909Storage.sol";
 
 // contracts
@@ -80,7 +79,9 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    return ERC6909Storage.getLayout().inner.transfer(to, id, amount);
+    ERC6909Storage.getLayout().inner.transfer(to, id, amount);
+    emit Transfer(msg.sender, msg.sender, to, id, amount);
+    return true;
   }
 
   /// @inheritdoc IERC6909
@@ -90,7 +91,9 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    return ERC6909Storage.getLayout().inner.transferFrom(from, to, id, amount);
+    ERC6909Storage.getLayout().inner.transferFrom(from, to, id, amount);
+    emit Transfer(msg.sender, from, to, id, amount);
+    return true;
   }
 
   /// @inheritdoc IERC6909
@@ -99,7 +102,9 @@ abstract contract ERC6909 is Facet, IERC6909 {
     uint256 id,
     uint256 amount
   ) external returns (bool) {
-    return ERC6909Storage.getLayout().inner.approve(spender, id, amount);
+    ERC6909Storage.getLayout().inner.approve(spender, id, amount);
+    emit Approval(msg.sender, spender, id, amount);
+    return true;
   }
 
   /// @inheritdoc IERC6909
@@ -107,7 +112,9 @@ abstract contract ERC6909 is Facet, IERC6909 {
     address operator,
     bool approved
   ) external returns (bool) {
-    return ERC6909Storage.getLayout().inner.setOperator(operator, approved);
+    ERC6909Storage.getLayout().inner.setOperator(operator, approved);
+    emit OperatorSet(msg.sender, operator, approved);
+    return true;
   }
 
   /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -115,10 +122,12 @@ abstract contract ERC6909 is Facet, IERC6909 {
   /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
   function _mint(address to, uint256 id, uint256 amount) internal virtual {
-    return ERC6909Storage.getLayout().inner.mint(to, id, amount);
+    ERC6909Storage.getLayout().inner.mint(to, id, amount);
+    emit Transfer(msg.sender, address(0), to, id, amount);
   }
 
   function _burn(address from, uint256 id, uint256 amount) internal virtual {
-    return ERC6909Storage.getLayout().inner.burn(from, id, amount);
+    ERC6909Storage.getLayout().inner.burn(from, id, amount);
+    emit Transfer(msg.sender, from, address(0), id, amount);
   }
 }

--- a/src/facets/token/ERC6909/ERC6909Storage.sol
+++ b/src/facets/token/ERC6909/ERC6909Storage.sol
@@ -8,11 +8,7 @@ library ERC6909Storage {
   bytes32 internal constant STORAGE_SLOT =
     0xf9f33862612718f5941a42fb684d74a72854935271a5691c69162b83a46f6d00;
 
-  struct Layout {
-    MinimalERC6909Storage inner;
-  }
-
-  function getLayout() internal pure returns (Layout storage l) {
+  function getLayout() internal pure returns (MinimalERC6909Storage storage l) {
     assembly {
       l.slot := STORAGE_SLOT
     }

--- a/src/facets/token/ERC6909/ERC6909Storage.sol
+++ b/src/facets/token/ERC6909/ERC6909Storage.sol
@@ -1,20 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import {MinimalERC6909Storage} from "../../../primitive/ERC6909.sol";
+
 library ERC6909Storage {
   // keccak256(abi.encode(uint256(keccak256("diamond.facets.token.ERC6909")) - 1)) & ~bytes32(uint256(0xff))
   bytes32 internal constant STORAGE_SLOT =
     0xf9f33862612718f5941a42fb684d74a72854935271a5691c69162b83a46f6d00;
 
   struct Layout {
-    // Mapping from (owner, id) to balance
-    mapping(address => mapping(uint256 => uint256)) balances;
-    // Mapping from (owner, spender, id) to allowance
-    mapping(address => mapping(address => mapping(uint256 => uint256))) allowances;
-    // Mapping from owner to operator approvals
-    mapping(address => mapping(address => bool)) operatorApprovals;
-    // Mapping from token id to total supply
-    mapping(uint256 => uint256) supply;
+    MinimalERC6909Storage inner;
   }
 
   function getLayout() internal pure returns (Layout storage l) {

--- a/src/facets/token/ERC6909/ERC6909Storage.sol
+++ b/src/facets/token/ERC6909/ERC6909Storage.sol
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import {MinimalERC6909Storage} from "../../../primitive/ERC6909.sol";
+import {ERC6909Lib} from "src/primitive/ERC6909.sol";
 
 library ERC6909Storage {
   // keccak256(abi.encode(uint256(keccak256("diamond.facets.token.ERC6909")) - 1)) & ~bytes32(uint256(0xff))
   bytes32 internal constant STORAGE_SLOT =
     0xf9f33862612718f5941a42fb684d74a72854935271a5691c69162b83a46f6d00;
 
-  function getLayout() internal pure returns (MinimalERC6909Storage storage l) {
+  function getLayout()
+    internal
+    pure
+    returns (ERC6909Lib.MinimalERC6909Storage storage l)
+  {
     assembly {
       l.slot := STORAGE_SLOT
     }

--- a/src/facets/token/ERC6909/IERC6909.sol
+++ b/src/facets/token/ERC6909/IERC6909.sol
@@ -10,9 +10,6 @@ interface IERC6909Base {
   /// @notice Thrown when an account has insufficient permission to perform an operation
   error InsufficientPermission();
 
-  /// @notice Thrown when a balance operation would cause an overflow
-  error BalanceOverflow();
-
   /// @notice The event emitted when a transfer occurs.
   /// @param caller The caller of the transfer.
   /// @param sender The address of the sender.

--- a/src/facets/token/ERC6909/IERC6909.sol
+++ b/src/facets/token/ERC6909/IERC6909.sol
@@ -4,11 +4,15 @@ pragma solidity ^0.8.19;
 /// @title ERC6909 Base Interface
 /// @notice Contains the core events used by the ERC6909 token standard
 interface IERC6909Base {
-  /// @notice Thrown when an account has insufficient balance for a transfer
-  error InsufficientBalance();
+  /// @notice Thrown when owner balance for id is insufficient.
+  /// @param owner The address of the owner.
+  /// @param id The id of the token.
+  error InsufficientBalance(address owner, uint256 id);
 
-  /// @notice Thrown when an account has insufficient permission to perform an operation
-  error InsufficientPermission();
+  /// @notice Thrown when spender allowance for id is insufficient.
+  /// @param spender The address of the spender.
+  /// @param id The id of the token.
+  error InsufficientPermission(address spender, uint256 id);
 
   /// @notice The event emitted when a transfer occurs.
   /// @param caller The caller of the transfer.

--- a/src/primitive/ERC6909.sol
+++ b/src/primitive/ERC6909.sol
@@ -1,21 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-// interfaces
-import {IERC6909Base} from "./IERC6909.sol";
+import {MinimalERC20Storage} from "./ERC20.sol";
+import {IERC6909Base} from "../facets/token/ERC6909/IERC6909.sol";
 
-// libraries
-import {ERC6909Storage} from "./ERC6909Storage.sol";
+using ERC6909 for MinimalERC6909Storage global;
 
-/// @title ERC6909Lib
-/// @notice Library implementing ERC6909 logic for multi-token standard
-/// @dev Implements core functionality for ERC6909 token standard
-library ERC6909Lib {
+/// @notice Minimal storage layout for ERC6909
+/// @dev Do not modify the layout of this struct especially if it's nested in another struct
+/// or used in a linear storage layout
+struct MinimalERC6909Storage {
+  mapping(uint256 id => MinimalERC20Storage) tokens;
+  mapping(address owner => mapping(address spender => bool)) operatorApprovals;
+}
+
+/// @title ERC6909
+/// @notice Minimal ERC6909 implementation
+library ERC6909 {
   /// @notice Returns the total supply of a specific token ID
   /// @param id The token ID to query
   /// @return The total supply of the token
-  function totalSupply(uint256 id) internal view returns (uint256) {
-    return ERC6909Storage.getLayout().supply[id];
+  function totalSupply(
+    MinimalERC6909Storage storage self,
+    uint256 id
+  ) internal view returns (uint256) {
+    return self.tokens[id].totalSupply;
   }
 
   /// @notice Returns the balance of a specific token ID for an account
@@ -23,10 +32,11 @@ library ERC6909Lib {
   /// @param id The token ID to query
   /// @return The balance of the specified token for the owner
   function balanceOf(
+    MinimalERC6909Storage storage self,
     address owner,
     uint256 id
   ) internal view returns (uint256) {
-    return ERC6909Storage.getLayout().balances[owner][id];
+    return self.tokens[id].balanceOf(owner);
   }
 
   /// @notice Returns the allowance of a spender for a specific token ID
@@ -35,11 +45,12 @@ library ERC6909Lib {
   /// @param id The token ID to query
   /// @return The remaining allowance of the spender
   function allowance(
+    MinimalERC6909Storage storage self,
     address owner,
     address spender,
     uint256 id
   ) internal view returns (uint256) {
-    return ERC6909Storage.getLayout().allowances[owner][spender][id];
+    return self.tokens[id].allowance(owner, spender);
   }
 
   /// @notice Checks if an address is an approved operator for an owner
@@ -47,23 +58,24 @@ library ERC6909Lib {
   /// @param spender The address to check operator status for
   /// @return True if the spender is an approved operator for the owner
   function isOperator(
+    MinimalERC6909Storage storage self,
     address owner,
     address spender
   ) internal view returns (bool) {
-    return ERC6909Storage.getLayout().operatorApprovals[owner][spender];
+    return self.operatorApprovals[owner][spender];
   }
 
   /// @notice Transfers tokens from the caller to another address
   /// @param to The address to transfer tokens to
   /// @param id The token ID to transfer
   /// @param amount The amount of tokens to transfer
-  /// @return True if the transfer was successful
   function transfer(
+    MinimalERC6909Storage storage self,
     address to,
     uint256 id,
     uint256 amount
   ) internal returns (bool) {
-    _transfer(msg.sender, to, id, amount);
+    _transfer(self, msg.sender, to, id, amount);
     return true;
   }
 
@@ -73,24 +85,32 @@ library ERC6909Lib {
   /// @param to The address to transfer tokens to
   /// @param id The token ID to transfer
   /// @param amount The amount of tokens to transfer
-  /// @return True if the transfer was successful
-  /// @custom:error InsufficientPermission Thrown if caller has insufficient allowance
   function transferFrom(
+    MinimalERC6909Storage storage self,
     address from,
     address to,
     uint256 id,
     uint256 amount
   ) internal returns (bool) {
-    if (!isOperator(from, msg.sender)) {
-      uint256 currentAllowance = allowance(from, msg.sender, id);
+    MinimalERC20Storage storage token = self.tokens[id];
+    if (msg.sender != from && !isOperator(self, from, msg.sender)) {
+      uint256 slot = token.allowances.slot(from, msg.sender);
+      uint256 currentAllowance;
+      assembly {
+        currentAllowance := sload(slot)
+      }
       if (currentAllowance != type(uint256).max) {
         if (currentAllowance < amount) {
           revert IERC6909Base.InsufficientPermission();
         }
-        _approve(from, msg.sender, id, currentAllowance - amount);
+        assembly {
+          sstore(slot, sub(currentAllowance, amount))
+        }
       }
     }
-    _transfer(from, to, id, amount);
+    token._deductBalance(from, amount);
+    token._increaseBalance(to, amount);
+    emit IERC6909Base.Transfer(msg.sender, from, to, id, amount);
     return true;
   }
 
@@ -98,13 +118,13 @@ library ERC6909Lib {
   /// @param spender The address to approve
   /// @param id The token ID to approve
   /// @param amount The amount of tokens to approve
-  /// @return True if the approval was successful
   function approve(
+    MinimalERC6909Storage storage self,
     address spender,
     uint256 id,
     uint256 amount
   ) internal returns (bool) {
-    _approve(msg.sender, spender, id, amount);
+    _approve(self, msg.sender, spender, id, amount);
     return true;
   }
 
@@ -112,14 +132,12 @@ library ERC6909Lib {
   /// @dev Operators can transfer any token ID owned by the caller
   /// @param operator The address to set operator status for
   /// @param approved True to approve the operator, false to revoke approval
-  /// @return True if the operation was successful
   function setOperator(
+    MinimalERC6909Storage storage self,
     address operator,
     bool approved
   ) internal returns (bool) {
-    ERC6909Storage.getLayout().operatorApprovals[msg.sender][
-      operator
-    ] = approved;
+    self.operatorApprovals[msg.sender][operator] = approved;
     emit IERC6909Base.OperatorSet(msg.sender, operator, approved);
     return true;
   }
@@ -129,20 +147,17 @@ library ERC6909Lib {
   /// @param to The address to mint tokens to
   /// @param id The token ID to mint
   /// @param amount The amount of tokens to mint
-  /// @custom:error BalanceOverflow Thrown if the recipient's balance would overflow
-  function mint(address to, uint256 id, uint256 amount) internal {
-    if (amount > 0) {
-      ERC6909Storage.Layout storage ds = ERC6909Storage.getLayout();
-
-      uint256 toBalanceBefore = ds.balances[to][id];
-      uint256 toBalanceAfter = toBalanceBefore + amount;
-      if (toBalanceAfter < toBalanceBefore)
-        revert IERC6909Base.BalanceOverflow();
-
-      ds.supply[id] += amount;
-      ds.balances[to][id] = toBalanceAfter;
-      emit IERC6909Base.Transfer(msg.sender, address(0), to, id, amount);
-    }
+  function mint(
+    MinimalERC6909Storage storage self,
+    address to,
+    uint256 id,
+    uint256 amount
+  ) internal {
+    MinimalERC20Storage storage token = self.tokens[id];
+    // Overflow check required: The rest of the code assumes that totalSupply never overflows
+    token.totalSupply += amount;
+    token._increaseBalance(to, amount);
+    emit IERC6909Base.Transfer(msg.sender, address(0), to, id, amount);
   }
 
   /// @notice Burns tokens from a specified address
@@ -150,54 +165,19 @@ library ERC6909Lib {
   /// @param from The address to burn tokens from
   /// @param id The token ID to burn
   /// @param amount The amount of tokens to burn
-  /// @custom:error InsufficientBalance Thrown if the holder has insufficient balance
-  function burn(address from, uint256 id, uint256 amount) internal {
-    if (amount > 0) {
-      ERC6909Storage.Layout storage ds = ERC6909Storage.getLayout();
-
-      uint256 fromBalance = ds.balances[from][id];
-      if (fromBalance < amount) revert IERC6909Base.InsufficientBalance();
-
-      unchecked {
-        ds.balances[from][id] = fromBalance - amount;
-        ds.supply[id] -= amount;
-      }
-      emit IERC6909Base.Transfer(msg.sender, from, address(0), id, amount);
-    }
-  }
-
-  /// @notice Internal function to transfer tokens between addresses
-  /// @dev Handles the actual transfer logic for transfer and transferFrom
-  /// @param from The address to transfer tokens from
-  /// @param to The address to transfer tokens to
-  /// @param id The token ID to transfer
-  /// @param amount The amount of tokens to transfer
-  /// @custom:error InsufficientBalance Thrown if the sender has insufficient balance
-  /// @custom:error BalanceOverflow Thrown if the recipient's balance would overflow
-  function _transfer(
+  function burn(
+    MinimalERC6909Storage storage self,
     address from,
-    address to,
     uint256 id,
     uint256 amount
-  ) private {
-    if (amount > 0) {
-      ERC6909Storage.Layout storage ds = ERC6909Storage.getLayout();
-
-      uint256 fromBalance = ds.balances[from][id];
-      if (fromBalance < amount) revert IERC6909Base.InsufficientBalance();
-
-      unchecked {
-        ds.balances[from][id] = fromBalance - amount;
-      }
-
-      uint256 toBalanceBefore = ds.balances[to][id];
-      uint256 toBalanceAfter = toBalanceBefore + amount;
-      if (toBalanceAfter < toBalanceBefore)
-        revert IERC6909Base.BalanceOverflow();
-
-      ds.balances[to][id] = toBalanceAfter;
-      emit IERC6909Base.Transfer(msg.sender, from, to, id, amount);
+  ) internal {
+    MinimalERC20Storage storage token = self.tokens[id];
+    token._deductBalance(from, amount);
+    unchecked {
+      // Overflow not possible: amount <= totalSupply or amount <= fromBalance <= totalSupply.
+      token.totalSupply -= amount;
     }
+    emit IERC6909Base.Transfer(msg.sender, from, address(0), id, amount);
   }
 
   /// @notice Internal function to approve a spender
@@ -207,12 +187,32 @@ library ERC6909Lib {
   /// @param id The token ID to approve
   /// @param amount The amount of tokens to approve
   function _approve(
+    MinimalERC6909Storage storage self,
     address owner,
     address spender,
     uint256 id,
     uint256 amount
-  ) private {
-    ERC6909Storage.getLayout().allowances[owner][spender][id] = amount;
+  ) internal {
+    self.tokens[id].allowances.set(owner, spender, amount);
     emit IERC6909Base.Approval(owner, spender, id, amount);
+  }
+
+  /// @notice Internal function to transfer tokens between addresses
+  /// @dev Handles the actual transfer logic for transfer and transferFrom
+  /// @param from The address to transfer tokens from
+  /// @param to The address to transfer tokens to
+  /// @param id The token ID to transfer
+  /// @param amount The amount of tokens to transfer
+  function _transfer(
+    MinimalERC6909Storage storage self,
+    address from,
+    address to,
+    uint256 id,
+    uint256 amount
+  ) internal {
+    MinimalERC20Storage storage token = self.tokens[id];
+    token._deductBalance(from, amount);
+    token._increaseBalance(to, amount);
+    emit IERC6909Base.Transfer(msg.sender, from, to, id, amount);
   }
 }

--- a/src/primitive/ERC6909.sol
+++ b/src/primitive/ERC6909.sol
@@ -4,20 +4,18 @@ pragma solidity ^0.8.19;
 import {MinimalERC20Storage} from "./ERC20.sol";
 import {IERC6909Base} from "../facets/token/ERC6909/IERC6909.sol";
 
-using ERC6909Lib for MinimalERC6909Storage global;
-
-/// @notice Minimal storage layout for ERC6909
-/// @dev Do not modify the layout of this struct especially if it's nested in another struct
-/// or used in a linear storage layout
-struct MinimalERC6909Storage {
-  mapping(uint256 id => MinimalERC20Storage) tokens;
-  mapping(address owner => mapping(address spender => bool)) operatorApprovals;
-}
-
 /// @title ERC6909Lib
 /// @notice Minimal ERC6909 implementation
 /// @dev The library implements the core functionality of an ERC6909 token without emitting events
 library ERC6909Lib {
+  /// @notice Minimal storage layout for ERC6909
+  /// @dev Do not modify the layout of this struct especially if it's nested in another struct
+  /// or used in a linear storage layout
+  struct MinimalERC6909Storage {
+    mapping(uint256 id => MinimalERC20Storage) tokens;
+    mapping(address owner => mapping(address spender => bool)) operatorApprovals;
+  }
+
   /// @notice Returns the total supply of a specific token ID
   /// @param id The token ID to query
   /// @return The total supply of the token

--- a/test/facets/token/ERC6909.t.sol
+++ b/test/facets/token/ERC6909.t.sol
@@ -83,13 +83,6 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     assertEq(facet.balanceOf(to, tokenId), amount);
   }
 
-  function test_allowance_gas()
-    public
-    givenAccountIsApproved(address(this), address(1), 1, 1 ether)
-  {
-    assertEq(facet.allowance(address(this), address(1), 1), 1 ether);
-  }
-
   function test_allowance(
     address owner,
     address spender,
@@ -177,12 +170,9 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
   function test_approve_gas()
     public
-    givenTokensAreMinted(address(this), 1, 1 ether)
+    givenAccountIsApproved(address(this), address(1), 1, 1 ether)
   {
-    address spender = address(1);
-    bool success = facet.approve(spender, 1, 1 ether);
-    assertTrue(success);
-    assertEq(facet.allowance(address(this), spender, 1), 1 ether);
+    assertEq(facet.allowance(address(this), address(1), 1), 1 ether);
   }
 
   function test_approve(

--- a/test/facets/token/ERC6909.t.sol
+++ b/test/facets/token/ERC6909.t.sol
@@ -37,48 +37,92 @@ contract ERC6909Test is TestUtils, IERC6909Base {
   }
 
   modifier givenAccountIsApproved(
-    address to,
-    address operator,
+    address owner,
+    address spender,
     uint256 tokenId,
     uint256 amount
   ) {
-    vm.assume(to != operator);
-    vm.prank(to);
-    facet.approve(operator, tokenId, amount);
+    vm.assume(owner != spender);
+    vm.prank(owner);
+    facet.approve(spender, tokenId, amount);
     _;
   }
 
-  modifier givenOperatorIsSet(address to, address operator, bool approved) {
-    vm.prank(to);
+  modifier givenOperatorIsSet(address owner, address operator, bool approved) {
+    vm.prank(owner);
     facet.setOperator(operator, approved);
     _;
   }
 
-  // Core functionality tests
+  function test_totalSupply_gas()
+    public
+    givenTokensAreMinted(address(this), 1, 1 ether)
+  {
+    assertEq(facet.totalSupply(1), 1 ether);
+  }
+
   function test_totalSupply(
+    uint256 tokenId,
+    uint256 amount
+  ) public givenTokensAreMinted(address(this), tokenId, amount) {
+    assertEq(facet.totalSupply(tokenId), amount);
+  }
+
+  function test_balanceOf_gas()
+    public
+    givenTokensAreMinted(address(this), 1, 1 ether)
+  {
+    assertEq(facet.balanceOf(address(this), 1), 1 ether);
+  }
+
+  function test_balanceOf(
     address to,
     uint256 tokenId,
     uint256 amount
   ) public givenTokensAreMinted(to, tokenId, amount) {
-    assertEq(facet.totalSupply(tokenId), amount);
     assertEq(facet.balanceOf(to, tokenId), amount);
   }
 
+  function test_allowance_gas()
+    public
+    givenAccountIsApproved(address(this), address(1), 1, 1 ether)
+  {
+    assertEq(facet.allowance(address(this), address(1), 1), 1 ether);
+  }
+
   function test_allowance(
-    address to,
-    address operator,
+    address owner,
+    address spender,
     uint256 tokenId,
     uint256 amount
-  ) public givenAccountIsApproved(to, operator, tokenId, amount) {
-    assertEq(facet.allowance(to, operator, tokenId), amount);
+  ) public givenAccountIsApproved(owner, spender, tokenId, amount) {
+    assertEq(facet.allowance(owner, spender, tokenId), amount);
+  }
+
+  function test_isOperator_gas()
+    public
+    givenOperatorIsSet(address(this), address(1), true)
+  {
+    assertTrue(facet.isOperator(address(this), address(1)));
   }
 
   function test_isOperator(
-    address to,
-    address operator,
+    address owner,
+    address spender,
     bool approved
-  ) public givenOperatorIsSet(to, operator, approved) {
-    assertEq(facet.isOperator(to, operator), approved);
+  ) public givenOperatorIsSet(owner, spender, approved) {
+    assertEq(facet.isOperator(owner, spender), approved);
+  }
+
+  function test_transfer_gas()
+    public
+    givenTokensAreMinted(address(this), 1, 1 ether)
+  {
+    address to = address(1);
+    bool success = facet.transfer(to, 1, 1 ether);
+    assertTrue(success);
+    assertEq(facet.balanceOf(address(this), 1), 0);
+    assertEq(facet.balanceOf(to, 1), 1 ether);
   }
 
   function test_transfer(
@@ -131,6 +175,16 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     facet.transfer(to, tokenId, amount);
   }
 
+  function test_approve_gas()
+    public
+    givenTokensAreMinted(address(this), 1, 1 ether)
+  {
+    address spender = address(1);
+    bool success = facet.approve(spender, 1, 1 ether);
+    assertTrue(success);
+    assertEq(facet.allowance(address(this), spender, 1), 1 ether);
+  }
+
   function test_approve(
     address owner,
     address spender,
@@ -149,6 +203,18 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
     assertTrue(success);
     assertEq(facet.allowance(owner, spender, tokenId), amount);
+  }
+
+  function test_transferFrom_gas()
+    public
+    givenTokensAreMinted(address(1), 1, 1 ether)
+    givenAccountIsApproved(address(1), address(this), 1, 1 ether)
+  {
+    address receiver = address(2);
+    bool success = facet.transferFrom(address(1), receiver, 1, 1 ether);
+    assertTrue(success);
+    assertEq(facet.balanceOf(address(1), 1), 0);
+    assertEq(facet.balanceOf(receiver, 1), 1 ether);
   }
 
   function test_transferFrom_withAllowance(
@@ -288,6 +354,13 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     facet.transferFrom(owner, receiver, tokenId, transferAmount);
   }
 
+  function test_setOperator_gas()
+    public
+    givenOperatorIsSet(address(this), address(1), true)
+  {
+    assertTrue(facet.isOperator(address(this), address(1)));
+  }
+
   function test_setOperator(
     address owner,
     address operator,
@@ -305,6 +378,15 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
     assertTrue(success);
     assertEq(facet.isOperator(owner, operator), approved);
+  }
+
+  function test_burn_gas()
+    public
+    givenTokensAreMinted(address(this), 1, 1 ether)
+  {
+    facet.burn(address(this), 1, 1 ether);
+    assertEq(facet.balanceOf(address(this), 1), 0);
+    assertEq(facet.totalSupply(1), 0);
   }
 
   function test_burn(
@@ -332,6 +414,14 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
     vm.expectRevert(IERC6909Base.InsufficientBalance.selector);
     facet.burn(from, tokenId, burnAmount);
+  }
+
+  function test_mint_gas()
+    public
+    givenTokensAreMinted(address(this), 1, 1 ether)
+  {
+    assertEq(facet.balanceOf(address(this), 1), 1 ether);
+    assertEq(facet.totalSupply(1), 1 ether);
   }
 
   function test_mint(address to, uint256 tokenId, uint256 amount) public {

--- a/test/facets/token/ERC6909.t.sol
+++ b/test/facets/token/ERC6909.t.sol
@@ -25,13 +25,21 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     facet = MockERC6909(deployMockERC6909Helper.deploy(deployer));
   }
 
-  modifier givenTokensAreMinted(address to, uint256 tokenId, uint256 amount) {
+  modifier givenTokensAreMinted(
+    address to,
+    uint256 tokenId,
+    uint256 amount
+  ) {
     vm.assume(to != address(0));
     facet.mint(to, tokenId, amount);
     _;
   }
 
-  modifier givenTokensAreBurned(address from, uint256 tokenId, uint256 amount) {
+  modifier givenTokensAreBurned(
+    address from,
+    uint256 tokenId,
+    uint256 amount
+  ) {
     facet.burn(from, tokenId, amount);
     _;
   }
@@ -48,7 +56,11 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     _;
   }
 
-  modifier givenOperatorIsSet(address owner, address operator, bool approved) {
+  modifier givenOperatorIsSet(
+    address owner,
+    address operator,
+    bool approved
+  ) {
     vm.prank(owner);
     facet.setOperator(operator, approved);
     _;
@@ -165,11 +177,7 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     // No tokens minted, so balance is 0
     vm.prank(from);
     vm.expectRevert(
-      abi.encodeWithSelector(
-        IERC6909Base.InsufficientBalance.selector,
-        from,
-        tokenId
-      )
+      abi.encodeWithSelector(InsufficientBalance.selector, from, tokenId)
     );
     facet.transfer(to, tokenId, amount);
   }
@@ -318,11 +326,7 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
     vm.prank(spender);
     vm.expectRevert(
-      abi.encodeWithSelector(
-        IERC6909Base.InsufficientPermission.selector,
-        spender,
-        tokenId
-      )
+      abi.encodeWithSelector(InsufficientPermission.selector, spender, tokenId)
     );
     facet.transferFrom(owner, receiver, tokenId, amount);
   }
@@ -353,11 +357,7 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
     vm.prank(spender);
     vm.expectRevert(
-      abi.encodeWithSelector(
-        IERC6909Base.InsufficientBalance.selector,
-        owner,
-        tokenId
-      )
+      abi.encodeWithSelector(InsufficientBalance.selector, owner, tokenId)
     );
     facet.transferFrom(owner, receiver, tokenId, transferAmount);
   }
@@ -421,11 +421,7 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     facet.mint(from, tokenId, mintAmount);
 
     vm.expectRevert(
-      abi.encodeWithSelector(
-        IERC6909Base.InsufficientBalance.selector,
-        from,
-        tokenId
-      )
+      abi.encodeWithSelector(InsufficientBalance.selector, from, tokenId)
     );
     facet.burn(from, tokenId, burnAmount);
   }

--- a/test/facets/token/ERC6909.t.sol
+++ b/test/facets/token/ERC6909.t.sol
@@ -164,7 +164,13 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
     // No tokens minted, so balance is 0
     vm.prank(from);
-    vm.expectRevert(IERC6909Base.InsufficientBalance.selector);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IERC6909Base.InsufficientBalance.selector,
+        from,
+        tokenId
+      )
+    );
     facet.transfer(to, tokenId, amount);
   }
 
@@ -311,7 +317,13 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     facet.approve(spender, tokenId, approvedAmount);
 
     vm.prank(spender);
-    vm.expectRevert(IERC6909Base.InsufficientPermission.selector);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IERC6909Base.InsufficientPermission.selector,
+        spender,
+        tokenId
+      )
+    );
     facet.transferFrom(owner, receiver, tokenId, amount);
   }
 
@@ -340,7 +352,13 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     facet.approve(spender, tokenId, transferAmount);
 
     vm.prank(spender);
-    vm.expectRevert(IERC6909Base.InsufficientBalance.selector);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IERC6909Base.InsufficientBalance.selector,
+        owner,
+        tokenId
+      )
+    );
     facet.transferFrom(owner, receiver, tokenId, transferAmount);
   }
 
@@ -402,7 +420,13 @@ contract ERC6909Test is TestUtils, IERC6909Base {
 
     facet.mint(from, tokenId, mintAmount);
 
-    vm.expectRevert(IERC6909Base.InsufficientBalance.selector);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IERC6909Base.InsufficientBalance.selector,
+        from,
+        tokenId
+      )
+    );
     facet.burn(from, tokenId, burnAmount);
   }
 


### PR DESCRIPTION
Replaced the old ERC6909Lib with a minimal library-based design for efficiency. Consolidated logic into the storage implementation, and ensured modularity by separating concerns between storage structures. Introduced changes to reduce emitted events in core libraries while keeping their handling at the contract level.