### PR TITLE
chore: add GitHub Actions for NPM publishing and project setup

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: NPM Publish
 
 on:
   release:
-    types: [ created ]
+    types: [created]
   workflow_dispatch:
     inputs:
       version:
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -26,19 +27,25 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Set version if provided
-        if: github.event.inputs.version != ''
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+      - name: Install Lerna
+        run: bun add -g lerna
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
 
+      - name: Build
+        run: bun run build
+
       - name: Run tests
         run: forge test
 
+      - name: Set version if provided
+        if: github.event.inputs.version != ''
+        run: lerna version ${{ github.event.inputs.version }} --no-push --no-git-tag-version --yes --force-publish
+
       - name: Publish to NPM
-        run: npm publish --access public
+        run: lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,44 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [ created ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 0.1.0)"
+        required: true
+        default: ""
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Set version if provided
+        if: github.event.inputs.version != ''
+        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Run tests
+        run: forge test
+
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+bun prettier:fix
+forge test

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+# Development files
+.git/
+.github/
+.vscode/
+.idea/
+.wake/
+.yarn/
+
+# Build artifacts
+cache/
+out/
+node_modules/
+bun.lock
+
+# Test files
+test/
+
+# Misc
+.gitignore
+foundry.toml
+remappings.txt

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 River Association
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.1.0",
+  "npmClient": "bun",
+  "command": {
+    "publish": {
+      "registry": "https://registry.npmjs.org/",
+      "access": "public"
+    },
+    "version": {
+      "allowBranch": "main",
+      "message": "chore(release): publish %s"
+    }
+  },
+  "packages": ["."]
+}

--- a/package.json
+++ b/package.json
@@ -1,17 +1,40 @@
 {
-  "name": "@river-build/diamond",
-  "version": "1.2.0",
+  "name": "@towns-protocol/diamond",
+  "version": "0.1.0",
+  "description": "A comprehensive toolkit for building modular smart contracts with the EIP-2535 Diamond Standard, including core contracts and optimized building blocks",
   "main": "index.js",
-  "repository": "git@github.com:river-build/diamond.git",
-  "author": "g <5714678+giuseppecrj@users.noreply.github.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/towns-protocol/diamond.git"
+  },
+  "keywords": [
+    "ethereum",
+    "solidity",
+    "smart-contracts",
+    "diamond-pattern",
+    "eip-2535",
+    "erc20",
+    "erc721",
+    "erc6909",
+    "upgradeable"
+  ],
+  "author": "Towns Protocol <hello@towns.com>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/towns-protocol/diamond/issues"
+  },
+  "homepage": "https://github.com/towns-protocol/diamond#readme",
   "files": [
     "src/**/*.sol",
-    "scripts/**/*.sol"
+    "scripts/**/*.sol",
+    "README.md"
   ],
   "scripts": {
-    "prettier": "prettier --check src/**/*.sol --config package.json",
-    "prettier:fix": "prettier --write {scripts,src,test}/**/*.sol"
+    "prettier": "prettier -c '{scripts,src,test}/**/*.sol' --config package.json",
+    "prettier:fix": "prettier -w '{scripts,src,test}/**/*.sol'",
+    "build": "forge build",
+    "test": "forge test",
+    "prepare": "husky"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.2.0",
@@ -20,6 +43,7 @@
   "devDependencies": {
     "@prb/test": "^0.6.4",
     "forge-std": "github:foundry-rs/forge-std#v1.9.6",
+    "husky": "^9.0.6",
     "prettier": "^3.5.3",
     "prettier-plugin-solidity": "^1.4.1"
   },

--- a/test/facets/token/ERC6909.t.sol
+++ b/test/facets/token/ERC6909.t.sol
@@ -25,21 +25,13 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     facet = MockERC6909(deployMockERC6909Helper.deploy(deployer));
   }
 
-  modifier givenTokensAreMinted(
-    address to,
-    uint256 tokenId,
-    uint256 amount
-  ) {
+  modifier givenTokensAreMinted(address to, uint256 tokenId, uint256 amount) {
     vm.assume(to != address(0));
     facet.mint(to, tokenId, amount);
     _;
   }
 
-  modifier givenTokensAreBurned(
-    address from,
-    uint256 tokenId,
-    uint256 amount
-  ) {
+  modifier givenTokensAreBurned(address from, uint256 tokenId, uint256 amount) {
     facet.burn(from, tokenId, amount);
     _;
   }
@@ -56,11 +48,7 @@ contract ERC6909Test is TestUtils, IERC6909Base {
     _;
   }
 
-  modifier givenOperatorIsSet(
-    address owner,
-    address operator,
-    bool approved
-  ) {
+  modifier givenOperatorIsSet(address owner, address operator, bool approved) {
     vm.prank(owner);
     facet.setOperator(operator, approved);
     _;


### PR DESCRIPTION
Introduce an automated workflow for publishing to NPM triggered by releases or manual input. Update project metadata, add `.npmignore` to exclude non-essential files, and configure Husky with a pre-commit hook. Improve scripts and dependency management for streamlined development and testing.