### PR TITLE
refactor: centralize facet deployment logic with reusable libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 env:

--- a/scripts/common/DeployBase.s.sol
+++ b/scripts/common/DeployBase.s.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.0;
 import {LibString} from "solady/utils/LibString.sol";
 
 // contracts
-
 import {Context} from "./Context.sol";
 import {DeployHelpers} from "./DeployHelpers.s.sol";
 import {Script} from "forge-std/Script.sol";

--- a/scripts/common/DeployFacet.s.sol
+++ b/scripts/common/DeployFacet.s.sol
@@ -23,8 +23,20 @@ contract DeployFacet is DeployBase {
     ///      - Constructs the artifact path and version name
     ///      - Uses DeployBase's deploy function with a curried deployment wrapper
     /// @return The address of the deployed facet contract
-    function run() external broadcastWith(msg.sender) returns (address) {
+    function run() external returns (address) {
         string memory name = vm.envString("CONTRACT_NAME");
+        return deploy(name, msg.sender);
+    }
+
+    /// @notice Deploys a facet contract using the provided name and deployer address
+    function deploy(
+        string memory name,
+        address deployer
+    )
+        public
+        broadcastWith(deployer)
+        returns (address)
+    {
         artifactPath = string.concat(outDir(), name, ".sol/", name, ".json");
         string memory versionName = string.concat("facets/", name);
 

--- a/scripts/common/deployers/SimpleDeployer.s.sol
+++ b/scripts/common/deployers/SimpleDeployer.s.sol
@@ -17,7 +17,7 @@ abstract contract SimpleDeployer is DeployBase {
     // - loading private keys
     // - saving deployments
     // - logging
-    function __deploy(address deployer) public virtual returns (address);
+    function __deploy(address deployer) internal virtual returns (address);
 
     // will first try to load existing deployments from `deployments/<network>/<contract>.json`
     // if OVERRIDE_DEPLOYMENTS is set to true or if no cached deployment is found:

--- a/scripts/deployments/diamonds/DeployDiamond.s.sol
+++ b/scripts/deployments/diamonds/DeployDiamond.s.sol
@@ -60,13 +60,11 @@ contract DeployDiamond is DiamondHelper, SimpleDeployer {
         });
     }
 
-    function __deploy(address deployer) public override returns (address) {
+    function __deploy(address deployer) internal override returns (address) {
         Diamond.InitParams memory initDiamondCut = diamondInitParams(deployer);
 
-        vm.startBroadcast(deployer);
+        vm.broadcast(deployer);
         Diamond diamond = new Diamond(initDiamondCut);
-        vm.stopBroadcast();
-
         return address(diamond);
     }
 }

--- a/scripts/deployments/facets/DeployDiamondCut.s.sol
+++ b/scripts/deployments/facets/DeployDiamondCut.s.sol
@@ -2,31 +2,40 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {DiamondCutFacet} from "../../../src/facets/cut/DiamondCutFacet.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployDiamondCut is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(DiamondCutFacet.diamondCut.selector);
+library DeployDiamondCut {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](1);
+        _selectors[0] = DiamondCutFacet.diamondCut.selector;
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return DiamondCutFacet.__DiamondCut_init.selector;
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "diamondCutFacet";
+    function makeInitData() internal pure returns (bytes memory) {
+        return abi.encodeCall(DiamondCutFacet.__DiamondCut_init, ());
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        DiamondCutFacet diamondCut = new DiamondCutFacet();
-        vm.stopBroadcast();
-        return address(diamondCut);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("DiamondCutFacet.sol", "");
     }
 }

--- a/scripts/deployments/facets/DeployDiamondLoupe.s.sol
+++ b/scripts/deployments/facets/DeployDiamondLoupe.s.sol
@@ -2,34 +2,43 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {DiamondLoupeFacet} from "../../../src/facets/loupe/DiamondLoupeFacet.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployDiamondLoupe is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(DiamondLoupeFacet.facets.selector);
-        addSelector(DiamondLoupeFacet.facetAddress.selector);
-        addSelector(DiamondLoupeFacet.facetFunctionSelectors.selector);
-        addSelector(DiamondLoupeFacet.facetAddresses.selector);
+library DeployDiamondLoupe {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](4);
+        _selectors[0] = DiamondLoupeFacet.facets.selector;
+        _selectors[1] = DiamondLoupeFacet.facetAddress.selector;
+        _selectors[2] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        _selectors[3] = DiamondLoupeFacet.facetAddresses.selector;
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return DiamondLoupeFacet.__DiamondLoupe_init.selector;
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "diamondLoupeFacet";
+    function makeInitData() internal pure returns (bytes memory) {
+        return abi.encodeCall(DiamondLoupeFacet.__DiamondLoupe_init, ());
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        DiamondLoupeFacet facet = new DiamondLoupeFacet();
-        vm.stopBroadcast();
-        return address(facet);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("DiamondLoupeFacet.sol", "");
     }
 }

--- a/scripts/deployments/facets/DeployIntrospection.s.sol
+++ b/scripts/deployments/facets/DeployIntrospection.s.sol
@@ -2,31 +2,40 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {IntrospectionFacet} from "../../../src/facets/introspection/IntrospectionFacet.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployIntrospection is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(IntrospectionFacet.supportsInterface.selector);
+library DeployIntrospection {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](1);
+        _selectors[0] = IntrospectionFacet.supportsInterface.selector;
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return IntrospectionFacet.__Introspection_init.selector;
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "introspectionFacet";
+    function makeInitData() internal pure returns (bytes memory) {
+        return abi.encodeCall(IntrospectionFacet.__Introspection_init, ());
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        IntrospectionFacet facet = new IntrospectionFacet();
-        vm.stopBroadcast();
-        return address(facet);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("IntrospectionFacet.sol", "");
     }
 }

--- a/scripts/deployments/facets/DeployManagedProxy.s.sol
+++ b/scripts/deployments/facets/DeployManagedProxy.s.sol
@@ -2,32 +2,41 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {ManagedProxyFacet} from "../../../src/proxy/managed/ManagedProxyFacet.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployManagedProxy is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(ManagedProxyFacet.getManager.selector);
-        addSelector(ManagedProxyFacet.setManager.selector);
+library DeployManagedProxy {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](2);
+        _selectors[0] = ManagedProxyFacet.getManager.selector;
+        _selectors[1] = ManagedProxyFacet.setManager.selector;
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return ManagedProxyFacet.__ManagedProxy_init.selector;
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "managedProxyFacet";
+    function makeInitData() internal pure returns (bytes memory) {
+        return abi.encodeCall(ManagedProxyFacet.__ManagedProxy_init, ());
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        ManagedProxyFacet managedProxy = new ManagedProxyFacet();
-        vm.stopBroadcast();
-        return address(managedProxy);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("ManagedProxyFacet.sol", "");
     }
 }

--- a/scripts/deployments/facets/DeployMultiInit.s.sol
+++ b/scripts/deployments/facets/DeployMultiInit.s.sol
@@ -1,27 +1,25 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.23;
 
+//libraries
+import {DeployLib} from "../../common/DeployLib.sol";
+
+//contracts
 import {MultiInit} from "../../../src/initializers/MultiInit.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
 
-contract DeployMultiInit is SimpleDeployer {
-    function versionName() public pure override returns (string memory) {
-        return "multiInit";
-    }
-
-    function __deploy(address deployer) public override returns (address) {
-        vm.broadcast(deployer);
-        return address(new MultiInit());
+library DeployMultiInit {
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("MultiInit.sol", "");
     }
 
     function makeInitData(
         address[] memory initAddresses,
         bytes[] memory initDatas
     )
-        public
+        internal
         pure
         returns (bytes memory)
     {
-        return abi.encodeWithSelector(MultiInit.multiInit.selector, initAddresses, initDatas);
+        return abi.encodeCall(MultiInit.multiInit, (initAddresses, initDatas));
     }
 }

--- a/scripts/deployments/facets/DeployOwnablePending.s.sol
+++ b/scripts/deployments/facets/DeployOwnablePending.s.sol
@@ -2,38 +2,43 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {OwnablePendingFacet} from "../../../src/facets/ownable/pending/OwnablePendingFacet.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployOwnablePending is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(OwnablePendingFacet.startTransferOwnership.selector);
-        addSelector(OwnablePendingFacet.acceptOwnership.selector);
-        addSelector(OwnablePendingFacet.currentOwner.selector);
-        addSelector(OwnablePendingFacet.pendingOwner.selector);
+library DeployOwnablePending {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](4);
+        _selectors[0] = OwnablePendingFacet.startTransferOwnership.selector;
+        _selectors[1] = OwnablePendingFacet.acceptOwnership.selector;
+        _selectors[2] = OwnablePendingFacet.currentOwner.selector;
+        _selectors[3] = OwnablePendingFacet.pendingOwner.selector;
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "ownablePendingFacet";
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        OwnablePendingFacet facet = new OwnablePendingFacet();
-        vm.stopBroadcast();
-        return address(facet);
+    function makeInitData(address owner) internal pure returns (bytes memory) {
+        return abi.encodeCall(OwnablePendingFacet.__OwnablePending_init, (owner));
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return OwnablePendingFacet.__OwnablePending_init.selector;
-    }
-
-    function makeInitData(address owner) public pure returns (bytes memory) {
-        return abi.encodeWithSelector(OwnablePendingFacet.__OwnablePending_init.selector, owner);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("OwnablePendingFacet.sol", "");
     }
 }

--- a/scripts/deployments/facets/DeployPausable.s.sol
+++ b/scripts/deployments/facets/DeployPausable.s.sol
@@ -2,33 +2,42 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {PausableFacet} from "../../../src/facets/pausable/PausableFacet.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployPausable is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(PausableFacet.pause.selector);
-        addSelector(PausableFacet.unpause.selector);
-        addSelector(PausableFacet.paused.selector);
+library DeployPausable {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](3);
+        _selectors[0] = PausableFacet.pause.selector;
+        _selectors[1] = PausableFacet.unpause.selector;
+        _selectors[2] = PausableFacet.paused.selector;
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "pausableFacet";
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        PausableFacet facet = new PausableFacet();
-        vm.stopBroadcast();
-        return address(facet);
+    function makeInitData() internal pure returns (bytes memory) {
+        return abi.encodeCall(PausableFacet.__Pausable_init, ());
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return PausableFacet.__Pausable_init.selector;
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("PausableFacet.sol", "");
     }
 }

--- a/scripts/deployments/facets/DeployTokenPausable.s.sol
+++ b/scripts/deployments/facets/DeployTokenPausable.s.sol
@@ -2,33 +2,42 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {TokenPausableFacet} from "../../../src/facets/pausable/token/TokenPausableFacet.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployTokenPausable is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(TokenPausableFacet.pause.selector);
-        addSelector(TokenPausableFacet.unpause.selector);
-        addSelector(TokenPausableFacet.paused.selector);
+library DeployTokenPausable {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](3);
+        _selectors[0] = TokenPausableFacet.pause.selector;
+        _selectors[1] = TokenPausableFacet.unpause.selector;
+        _selectors[2] = TokenPausableFacet.paused.selector;
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "tokenPausableFacet";
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        TokenPausableFacet facet = new TokenPausableFacet();
-        vm.stopBroadcast();
-        return address(facet);
+    function makeInitData() internal pure returns (bytes memory) {
+        return abi.encodeCall(TokenPausableFacet.__Pausable_init, ());
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return TokenPausableFacet.__Pausable_init.selector;
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("TokenPausableFacet.sol", "");
     }
 }

--- a/scripts/deployments/mocks/DeployMockERC20Permit.s.sol
+++ b/scripts/deployments/mocks/DeployMockERC20Permit.s.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IDiamond} from "src/IDiamond.sol";
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 // libraries
-import {DeployLib} from "scripts/common/DeployLib.sol";
+import {DeployLib} from "../../common/DeployLib.sol";
 
 // contracts
-import {ERC20} from "src/facets/token/ERC20/ERC20.sol";
-import {ERC20PermitBase} from "src/facets/token/ERC20/permit/ERC20PermitBase.sol";
-import {MockERC20Permit} from "test/mocks/MockERC20Permit.sol";
+import {ERC20} from "../../../src/facets/token/ERC20/ERC20.sol";
+import {ERC20PermitBase} from "../../../src/facets/token/ERC20/permit/ERC20PermitBase.sol";
+import {MockERC20Permit} from "../../../test/mocks/MockERC20Permit.sol";
 
 library DeployMockERC20Permit {
     function selectors() internal pure returns (bytes4[] memory _selectors) {

--- a/scripts/deployments/mocks/DeployMockERC6909.s.sol
+++ b/scripts/deployments/mocks/DeployMockERC6909.s.sol
@@ -2,44 +2,53 @@
 pragma solidity ^0.8.23;
 
 // interfaces
-import {IERC6909} from "src/facets/token/ERC6909/IERC6909.sol";
+import {IDiamond} from "../../../src/IDiamond.sol";
+import {IERC6909} from "../../../src/facets/token/ERC6909/IERC6909.sol";
 
 // libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 // contracts
-import {SimpleDeployer} from "scripts/common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "scripts/common/helpers/FacetHelper.s.sol";
-import {ERC6909} from "src/facets/token/ERC6909/ERC6909.sol";
-import {MockERC6909} from "test/mocks/MockERC6909.sol";
+import {ERC6909} from "../../../src/facets/token/ERC6909/ERC6909.sol";
+import {MockERC6909} from "../../../test/mocks/MockERC6909.sol";
 
-contract DeployMockERC6909 is SimpleDeployer, FacetHelper {
-    constructor() {
+library DeployMockERC6909 {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](15);
         // ERC6909
-        addSelector(ERC6909.name.selector);
-        addSelector(ERC6909.symbol.selector);
-        addSelector(ERC6909.decimals.selector);
-        addSelector(ERC6909.contractURI.selector);
-        addSelector(ERC6909.tokenURI.selector);
-        addSelector(IERC6909.totalSupply.selector);
-        addSelector(IERC6909.balanceOf.selector);
-        addSelector(IERC6909.allowance.selector);
-        addSelector(IERC6909.isOperator.selector);
-        addSelector(IERC6909.transfer.selector);
-        addSelector(IERC6909.transferFrom.selector);
-        addSelector(IERC6909.approve.selector);
-        addSelector(IERC6909.setOperator.selector);
-        addSelector(MockERC6909.mint.selector);
-        addSelector(MockERC6909.burn.selector);
+        _selectors[0] = ERC6909.name.selector;
+        _selectors[1] = ERC6909.symbol.selector;
+        _selectors[2] = ERC6909.decimals.selector;
+        _selectors[3] = ERC6909.contractURI.selector;
+        _selectors[4] = ERC6909.tokenURI.selector;
+        _selectors[5] = IERC6909.totalSupply.selector;
+        _selectors[6] = IERC6909.balanceOf.selector;
+        _selectors[7] = IERC6909.allowance.selector;
+        _selectors[8] = IERC6909.isOperator.selector;
+        _selectors[9] = IERC6909.transfer.selector;
+        _selectors[10] = IERC6909.transferFrom.selector;
+        _selectors[11] = IERC6909.approve.selector;
+        _selectors[12] = IERC6909.setOperator.selector;
+        _selectors[13] = MockERC6909.mint.selector;
+        _selectors[14] = MockERC6909.burn.selector;
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "mockERC6909";
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        MockERC6909 facet = new MockERC6909();
-        vm.stopBroadcast();
-        return address(facet);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("MockERC6909.sol", "");
     }
 }

--- a/scripts/deployments/mocks/DeployMockERC721.sol
+++ b/scripts/deployments/mocks/DeployMockERC721.sol
@@ -2,53 +2,58 @@
 pragma solidity ^0.8.23;
 
 // interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 // libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 // contracts
-import {SimpleDeployer} from "scripts/common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "scripts/common/helpers/FacetHelper.s.sol";
-import {ERC721} from "src/facets/token/ERC721/ERC721.sol";
-import {MockERC721} from "test/mocks/MockERC721.sol";
+import {ERC721} from "../../../src/facets/token/ERC721/ERC721.sol";
+import {MockERC721} from "../../../test/mocks/MockERC721.sol";
 
-contract DeployMockERC721 is SimpleDeployer, FacetHelper {
-    constructor() {
+library DeployMockERC721 {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](10);
         // ERC721
-        addSelector(ERC721.totalSupply.selector);
-        addSelector(ERC721.balanceOf.selector);
-        addSelector(ERC721.ownerOf.selector);
-        addSelector(ERC721.approve.selector);
-        addSelector(ERC721.getApproved.selector);
-        addSelector(ERC721.setApprovalForAll.selector);
-        addSelector(ERC721.isApprovedForAll.selector);
-        addSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256)")));
-        addSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)")));
-        addSelector(ERC721.transferFrom.selector);
+        _selectors[0] = ERC721.totalSupply.selector;
+        _selectors[1] = ERC721.balanceOf.selector;
+        _selectors[2] = ERC721.ownerOf.selector;
+        _selectors[3] = ERC721.approve.selector;
+        _selectors[4] = ERC721.getApproved.selector;
+        _selectors[5] = ERC721.setApprovalForAll.selector;
+        _selectors[6] = ERC721.isApprovedForAll.selector;
+        _selectors[7] = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
+        _selectors[8] = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
+        _selectors[9] = ERC721.transferFrom.selector;
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "mockERC721";
-    }
-
-    function initializer() public pure override returns (bytes4) {
-        return ERC721.__ERC721_init.selector;
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
     function makeInitData(
         string memory name,
         string memory symbol
     )
-        public
+        internal
         pure
         returns (bytes memory)
     {
-        return abi.encodeWithSelector(initializer(), name, symbol);
+        return abi.encodeCall(ERC721.__ERC721_init, (name, symbol));
     }
 
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        MockERC721 facet = new MockERC721();
-        vm.stopBroadcast();
-        return address(facet);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("MockERC721.sol", "");
     }
 }

--- a/scripts/deployments/utils/DeployProxyManager.s.sol
+++ b/scripts/deployments/utils/DeployProxyManager.s.sol
@@ -2,36 +2,41 @@
 pragma solidity ^0.8.23;
 
 //interfaces
+import {IDiamond} from "../../../src/IDiamond.sol";
 
 //libraries
+import {DeployLib} from "../../common/DeployLib.sol";
 
 //contracts
 import {ProxyManager} from "../../../src/proxy/manager/ProxyManager.sol";
-import {SimpleDeployer} from "../../common/deployers/SimpleDeployer.s.sol";
-import {FacetHelper} from "../../common/helpers/FacetHelper.s.sol";
 
-contract DeployProxyManager is FacetHelper, SimpleDeployer {
-    constructor() {
-        addSelector(ProxyManager.getImplementation.selector);
-        addSelector(ProxyManager.setImplementation.selector);
+library DeployProxyManager {
+    function selectors() internal pure returns (bytes4[] memory _selectors) {
+        _selectors = new bytes4[](2);
+        _selectors[0] = ProxyManager.getImplementation.selector;
+        _selectors[1] = ProxyManager.setImplementation.selector;
     }
 
-    function initializer() public pure override returns (bytes4) {
-        return ProxyManager.__ProxyManager_init.selector;
+    function makeCut(
+        address facetAddress,
+        IDiamond.FacetCutAction action
+    )
+        internal
+        pure
+        returns (IDiamond.FacetCut memory)
+    {
+        return IDiamond.FacetCut({
+            action: action,
+            facetAddress: facetAddress,
+            functionSelectors: selectors()
+        });
     }
 
-    function makeInitData(address implementation) public pure returns (bytes memory) {
-        return abi.encodeWithSelector(initializer(), implementation);
+    function makeInitData(address implementation) internal pure returns (bytes memory) {
+        return abi.encodeCall(ProxyManager.__ProxyManager_init, (implementation));
     }
 
-    function versionName() public pure override returns (string memory) {
-        return "proxyManagerFacet";
-    }
-
-    function __deploy(address deployer) public override returns (address) {
-        vm.startBroadcast(deployer);
-        ProxyManager proxyManager = new ProxyManager();
-        vm.stopBroadcast();
-        return address(proxyManager);
+    function deploy() internal returns (address) {
+        return DeployLib.deployCode("ProxyManager.sol", "");
     }
 }

--- a/test/facets/cut/DiamondCut.t.sol
+++ b/test/facets/cut/DiamondCut.t.sol
@@ -23,7 +23,6 @@ import {DeployMockFacet, MockFacet} from "test/mocks/MockFacet.sol";
 contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     DeployMockFacet mockFacetHelper = new DeployMockFacet();
     DeployDiamond diamondHelper = new DeployDiamond();
-    DeployDiamondCut diamondCutHelper = new DeployDiamondCut();
 
     address diamond;
     address deployer;
@@ -303,7 +302,8 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     }
 
     function test_revertWhenReplacingDiamondCut() external {
-        address cutFacet = diamondCutHelper.deploy(deployer);
+        vm.prank(deployer);
+        address cutFacet = DeployDiamondCut.deploy();
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = IDiamondCut.diamondCut.selector;
 

--- a/test/facets/cut/DiamondCut.t.sol
+++ b/test/facets/cut/DiamondCut.t.sol
@@ -21,7 +21,6 @@ import {DeployDiamondCut} from "scripts/deployments/facets/DeployDiamondCut.s.so
 import {DeployMockFacet, MockFacet} from "test/mocks/MockFacet.sol";
 
 contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
-    DeployMockFacet mockFacetHelper = new DeployMockFacet();
     DeployDiamond diamondHelper = new DeployDiamond();
 
     address diamond;
@@ -42,9 +41,10 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
 
     function test_diamondCut() external {
         // create facet cuts
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
         vm.expectEmit(true, true, true, true, diamond);
         emit DiamondCut(extensions, address(0), "");
         // cut diamond
@@ -56,9 +56,10 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
 
     function test_diamondCut_reverts_when_not_owner() external {
         // create facet selectors
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
         address caller = _randomAddress();
         vm.expectRevert(abi.encodeWithSelector(Ownable__NotOwner.selector, caller));
         vm.prank(caller);
@@ -66,9 +67,10 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     }
 
     function test_reverts_when_init_not_contract() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
         address init = _randomAddress();
         vm.expectRevert(abi.encodeWithSelector(DiamondCut_InvalidContract.selector, init));
         vm.prank(deployer);
@@ -102,7 +104,8 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     }
 
     function test_revertsWhenSelectorArrayIsEmpty() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         facetCuts.push(
             IDiamond.FacetCut({
                 facetAddress: address(mockFacet),
@@ -119,9 +122,10 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
 
     function test_revertWhen_initializeDiamondCut() external {
         // create facet selectors
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
         // cut diamond
         vm.expectRevert(Errors.FailedCall.selector);
         vm.prank(deployer);
@@ -132,9 +136,10 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     //                           Add Facet
     // =============================================================
     function test_revertWhenAddingFunctionAlreadyExists() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
         vm.prank(deployer);
         diamondCut.diamondCut(extensions, address(0), "");
         vm.expectRevert(
@@ -147,7 +152,8 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     }
 
     function test_revertWhenAddingZeroSelector() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         bytes4[] memory facetSelectors = new bytes4[](1);
         facetSelectors[0] = bytes4(0);
         facetCuts.push(
@@ -166,7 +172,8 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     //                        Remove Facet
     // =============================================================
     function test_revertWhenRemovingFromOtherFacet() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         // create facet selectors
         bytes4[] memory facetSelectors = new bytes4[](1);
         facetSelectors[0] = IMockFacet.mockFunction.selector;
@@ -199,7 +206,8 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     }
 
     function test_revertWhenRemovingZeroSelector() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         // create facet selectors
         bytes4[] memory facetSelectors = new bytes4[](1);
         facetSelectors[0] = IMockFacet.mockFunction.selector;
@@ -244,7 +252,8 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     //                        Replace Facet
     // =============================================================
     function test_revertWhenReplacingZeroSelector() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         bytes4[] memory facetSelectors = new bytes4[](1);
         facetSelectors[0] = bytes4(0);
         facetCuts.push(
@@ -260,7 +269,8 @@ contract DiamondCutTest is TestUtils, IDiamondCutBase, IOwnableBase {
     }
 
     function test_revertWhenReplacingFunctionFromSameFacet() external {
-        address mockFacet = mockFacetHelper.deploy(deployer);
+        vm.prank(deployer);
+        address mockFacet = DeployMockFacet.deploy();
         bytes4[] memory facetSelectors = new bytes4[](1);
         facetSelectors[0] = IMockFacet.mockFunction.selector;
         facetCuts.push(

--- a/test/facets/loupe/DiamondLoupe.t.sol
+++ b/test/facets/loupe/DiamondLoupe.t.sol
@@ -18,7 +18,6 @@ import {DeployMockFacet, MockFacet} from "test/mocks/MockFacet.sol";
 
 contract DiamondLoupeTest is TestUtils, IDiamondLoupeBase {
     DeployDiamond diamondHelper = new DeployDiamond();
-    DeployMockFacet mockFacetHelper = new DeployMockFacet();
 
     address diamond;
     address deployer;
@@ -37,8 +36,8 @@ contract DiamondLoupeTest is TestUtils, IDiamondLoupeBase {
     }
 
     function test_facets() external {
-        address mockFacet = mockFacetHelper.deploy();
-        bytes4[] memory expectedSelectors = mockFacetHelper.selectors();
+        address mockFacet = DeployMockFacet.deploy();
+        bytes4[] memory expectedSelectors = DeployMockFacet.selectors();
         IDiamondLoupe.Facet[] memory currentFacets = diamondLoupe.facets();
 
         // create facet cuts
@@ -61,8 +60,8 @@ contract DiamondLoupeTest is TestUtils, IDiamondLoupeBase {
     }
 
     function test_facetFunctionSelectors() external {
-        address mockFacet = mockFacetHelper.deploy();
-        bytes4[] memory expectedSelectors = mockFacetHelper.selectors();
+        address mockFacet = DeployMockFacet.deploy();
+        bytes4[] memory expectedSelectors = DeployMockFacet.selectors();
 
         // create facet cuts
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
@@ -90,8 +89,8 @@ contract DiamondLoupeTest is TestUtils, IDiamondLoupeBase {
     }
 
     function test_facetAddresses() external {
-        address mockFacet = mockFacetHelper.deploy();
-        bytes4[] memory expectedSelectors = mockFacetHelper.selectors();
+        address mockFacet = DeployMockFacet.deploy();
+        bytes4[] memory expectedSelectors = DeployMockFacet.selectors();
         address[] memory currentFacetAddresses = diamondLoupe.facetAddresses();
 
         // create facet cuts
@@ -117,8 +116,8 @@ contract DiamondLoupeTest is TestUtils, IDiamondLoupeBase {
     }
 
     function test_facetAddress() external {
-        address mockFacet = mockFacetHelper.deploy();
-        bytes4[] memory expectedSelectors = mockFacetHelper.selectors();
+        address mockFacet = DeployMockFacet.deploy();
+        bytes4[] memory expectedSelectors = DeployMockFacet.selectors();
 
         // create facet cuts
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
@@ -140,8 +139,8 @@ contract DiamondLoupeTest is TestUtils, IDiamondLoupeBase {
     }
 
     function test_facetAddressRemove() external {
-        address mockFacet = mockFacetHelper.deploy();
-        bytes4[] memory expectedSelectors = mockFacetHelper.selectors();
+        address mockFacet = DeployMockFacet.deploy();
+        bytes4[] memory expectedSelectors = DeployMockFacet.selectors();
 
         // create facet cuts
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
@@ -174,8 +173,8 @@ contract DiamondLoupeTest is TestUtils, IDiamondLoupeBase {
     }
 
     function test_facetAddressReplace() external {
-        address mockFacet = mockFacetHelper.deploy();
-        bytes4[] memory expectedSelectors = mockFacetHelper.selectors();
+        address mockFacet = DeployMockFacet.deploy();
+        bytes4[] memory expectedSelectors = DeployMockFacet.selectors();
 
         // create facet cuts
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);

--- a/test/facets/ownable/Ownable.t.sol
+++ b/test/facets/ownable/Ownable.t.sol
@@ -17,7 +17,6 @@ import {OwnableFacet} from "src/facets/ownable/OwnableFacet.sol";
 
 contract OwnableTest is TestUtils, IOwnableBase {
     DeployDiamond diamondHelper = new DeployDiamond();
-    DeployOwnable ownableHelper = new DeployOwnable();
 
     address diamond;
     address deployer;
@@ -28,8 +27,9 @@ contract OwnableTest is TestUtils, IOwnableBase {
     function setUp() public {
         deployer = getDeployer();
 
-        address ownableFacet = ownableHelper.deploy(deployer);
-        diamondHelper.addCut(ownableHelper.makeCut(ownableFacet, IDiamond.FacetCutAction.Add));
+        vm.prank(deployer);
+        address ownableFacet = DeployOwnable.deploy();
+        diamondHelper.addCut(DeployOwnable.makeCut(ownableFacet, IDiamond.FacetCutAction.Add));
 
         diamond = diamondHelper.deploy(deployer);
         ownable = IERC173(diamond);

--- a/test/facets/ownable/pending/OwnablePending.t.sol
+++ b/test/facets/ownable/pending/OwnablePending.t.sol
@@ -17,7 +17,6 @@ import {OwnablePendingFacet} from "src/facets/ownable/pending/OwnablePendingFace
 
 contract OwnablePendingTest is TestUtils, IOwnableBase {
     DeployDiamond diamondHelper = new DeployDiamond();
-    DeployOwnablePending ownablePendingHelper = new DeployOwnablePending();
 
     address diamond;
     address deployer;
@@ -28,10 +27,11 @@ contract OwnablePendingTest is TestUtils, IOwnableBase {
     function setUp() public {
         deployer = getDeployer();
 
-        address ownablePending = ownablePendingHelper.deploy(deployer);
+        vm.prank(deployer);
+        address ownablePending = DeployOwnablePending.deploy();
 
         diamondHelper.addCut(
-            ownablePendingHelper.makeCut(ownablePending, IDiamond.FacetCutAction.Add)
+            DeployOwnablePending.makeCut(ownablePending, IDiamond.FacetCutAction.Add)
         );
 
         diamond = diamondHelper.deploy(deployer);

--- a/test/facets/ownable/token/TokenOwnable.t.sol
+++ b/test/facets/ownable/token/TokenOwnable.t.sol
@@ -20,7 +20,6 @@ import {MockToken} from "test/mocks/MockToken.sol";
 
 contract TokenOwnableTest is TestUtils, ITokenOwnableBase {
     DeployDiamond diamondHelper = new DeployDiamond();
-    DeployTokenOwnable tokenOwnableHelper = new DeployTokenOwnable();
 
     address diamond;
     address deployer;
@@ -34,15 +33,16 @@ contract TokenOwnableTest is TestUtils, ITokenOwnableBase {
         deployer = getDeployer();
         owner = makeAddr("owner");
 
-        address tokenOwnableFacet = tokenOwnableHelper.deploy(deployer);
+        vm.prank(deployer);
+        address tokenOwnableFacet = DeployTokenOwnable.deploy();
 
         mockToken = new MockToken();
         tokenId = mockToken.mintTo(owner);
 
         diamondHelper.addFacet(
-            tokenOwnableHelper.makeCut(tokenOwnableFacet, IDiamond.FacetCutAction.Add),
+            DeployTokenOwnable.makeCut(tokenOwnableFacet, IDiamond.FacetCutAction.Add),
             tokenOwnableFacet,
-            tokenOwnableHelper.makeInitData(TokenOwnable(address(mockToken), tokenId))
+            DeployTokenOwnable.makeInitData(TokenOwnable(address(mockToken), tokenId))
         );
 
         diamond = diamondHelper.deploy(deployer);

--- a/test/facets/pausable/Pausable.t.sol
+++ b/test/facets/pausable/Pausable.t.sol
@@ -17,7 +17,6 @@ import {PausableFacet} from "src/facets/pausable/PausableFacet.sol";
 
 contract PausableTest is TestUtils, IPausableBase {
     DeployDiamond diamondHelper = new DeployDiamond();
-    DeployPausable pausableHelper = new DeployPausable();
 
     address diamond;
     address deployer;
@@ -26,12 +25,13 @@ contract PausableTest is TestUtils, IPausableBase {
 
     function setUp() public {
         deployer = getDeployer();
-        address pausableFacet = pausableHelper.deploy(deployer);
+        vm.prank(deployer);
+        address pausableFacet = DeployPausable.deploy();
 
         diamondHelper.addFacet(
-            pausableHelper.makeCut(pausableFacet, IDiamond.FacetCutAction.Add),
+            DeployPausable.makeCut(pausableFacet, IDiamond.FacetCutAction.Add),
             pausableFacet,
-            pausableHelper.makeInitData("")
+            DeployPausable.makeInitData()
         );
 
         diamond = diamondHelper.deploy(deployer);

--- a/test/facets/pausable/TokenPausable.t.sol
+++ b/test/facets/pausable/TokenPausable.t.sol
@@ -22,8 +22,6 @@ import {MockToken} from "test/mocks/MockToken.sol";
 
 contract TokenPausableTest is TestUtils, ITokenOwnableBase, IPausableBase {
     DeployDiamond diamondHelper = new DeployDiamond();
-    DeployTokenOwnable tokenOwnableHelper = new DeployTokenOwnable();
-    DeployTokenPausable tokenPausableHelper = new DeployTokenPausable();
 
     address diamond;
     address deployer;
@@ -41,19 +39,21 @@ contract TokenPausableTest is TestUtils, ITokenOwnableBase, IPausableBase {
         mockToken = new MockToken();
         tokenId = mockToken.mintTo(owner);
 
-        address tokenOwnableFacet = tokenOwnableHelper.deploy(deployer);
-        address tokenPausableFacet = tokenPausableHelper.deploy(deployer);
+        vm.startPrank(deployer);
+        address tokenOwnableFacet = DeployTokenOwnable.deploy();
+        address tokenPausableFacet = DeployTokenPausable.deploy();
+        vm.stopPrank();
 
         diamondHelper.addFacet(
-            tokenOwnableHelper.makeCut(tokenOwnableFacet, IDiamond.FacetCutAction.Add),
+            DeployTokenOwnable.makeCut(tokenOwnableFacet, IDiamond.FacetCutAction.Add),
             tokenOwnableFacet,
-            tokenOwnableHelper.makeInitData(TokenOwnable(address(mockToken), tokenId))
+            DeployTokenOwnable.makeInitData(TokenOwnable(address(mockToken), tokenId))
         );
 
         diamondHelper.addFacet(
-            tokenPausableHelper.makeCut(tokenPausableFacet, IDiamond.FacetCutAction.Add),
+            DeployTokenPausable.makeCut(tokenPausableFacet, IDiamond.FacetCutAction.Add),
             tokenPausableFacet,
-            tokenPausableHelper.makeInitData("")
+            DeployTokenPausable.makeInitData()
         );
 
         diamond = diamondHelper.deploy(deployer);

--- a/test/facets/token/ERC6909.t.sol
+++ b/test/facets/token/ERC6909.t.sol
@@ -14,15 +14,13 @@ import {DeployMockERC6909} from "scripts/deployments/mocks/DeployMockERC6909.s.s
 import {MockERC6909} from "test/mocks/MockERC6909.sol";
 
 contract ERC6909Test is TestUtils, IERC6909Base {
-    DeployMockERC6909 deployMockERC6909Helper = new DeployMockERC6909();
     MockERC6909 facet;
 
-    address deployer;
     address constant ZERO_ADDRESS = address(0);
 
     function setUp() external {
-        deployer = getDeployer();
-        facet = MockERC6909(deployMockERC6909Helper.deploy(deployer));
+        vm.prank(getDeployer());
+        facet = MockERC6909(DeployMockERC6909.deploy());
     }
 
     modifier givenTokensAreMinted(address to, uint256 tokenId, uint256 amount) {

--- a/test/facets/token/ERC721.t.sol
+++ b/test/facets/token/ERC721.t.sol
@@ -13,15 +13,11 @@ import {DeployMockERC721} from "scripts/deployments/mocks/DeployMockERC721.sol";
 import {MockERC721} from "test/mocks/MockERC721.sol";
 
 contract ERC721Test is TestUtils {
-    DeployMockERC721 deployMockERC721Helper = new DeployMockERC721();
-
     MockERC721 mockERC721;
 
-    address deployer;
-
     function setUp() external {
-        deployer = getDeployer();
-        mockERC721 = MockERC721(deployMockERC721Helper.deploy(deployer));
+        vm.prank(getDeployer());
+        mockERC721 = MockERC721(DeployMockERC721.deploy());
     }
 
     modifier givenTokensAreMinted(address to, uint256 tokenId) {

--- a/test/proxy/ProxyManager.t.sol
+++ b/test/proxy/ProxyManager.t.sol
@@ -41,7 +41,6 @@ import {MockProxyInstance} from "test/mocks/MockProxyInstance.sol";
 /// - Control access to implementation updates
 /// - Maintain proper proxy-implementation relationships
 contract ProxyManagerTest is TestUtils, IDiamondCutBase, IOwnableBase {
-    DeployMockFacet mockFacetHelper = new DeployMockFacet();
     DeployFacet private facetHelper = new DeployFacet();
 
     address manager;
@@ -142,10 +141,10 @@ contract ProxyManagerTest is TestUtils, IDiamondCutBase, IOwnableBase {
 
     /// @notice This test adds a new facet to our main implementation, which means our instance should now have access to it as well
     function test_instanceHasImplementationGlobalFacet() external {
-        address mockFacet = mockFacetHelper.deploy();
+        address mockFacet = DeployMockFacet.deploy();
 
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
 
         vm.prank(deployer);
         IDiamondCut(address(implementation)).diamondCut(extensions, address(0), "");
@@ -155,10 +154,10 @@ contract ProxyManagerTest is TestUtils, IDiamondCutBase, IOwnableBase {
 
     /// @notice This test reverts when the implementation owner calls diamondCut on the implementation
     function test_revertWhen_diamondCutByWrongOwner() external {
-        address mockFacet = mockFacetHelper.deploy();
+        address mockFacet = DeployMockFacet.deploy();
 
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
 
         vm.prank(instanceOwner);
         vm.expectRevert();
@@ -173,9 +172,8 @@ contract ProxyManagerTest is TestUtils, IDiamondCutBase, IOwnableBase {
     function test_instanceContainsLocalFacet() external {
         // add some facets to diamond
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(
-            mockFacetHelper.deploy(instanceOwner), IDiamond.FacetCutAction.Add
-        );
+        extensions[0] =
+            DeployMockFacet.makeCut(DeployMockFacet.deploy(), IDiamond.FacetCutAction.Add);
 
         vm.prank(instanceOwner);
         IDiamondCut(address(instance)).diamondCut(extensions, address(0), "");
@@ -202,11 +200,11 @@ contract ProxyManagerTest is TestUtils, IDiamondCutBase, IOwnableBase {
     }
 
     function test_upgradePath() external {
-        address mockFacet = mockFacetHelper.deploy();
+        address mockFacet = DeployMockFacet.deploy();
 
         // add mock facet to implementation
         IDiamond.FacetCut[] memory extensions = new IDiamond.FacetCut[](1);
-        extensions[0] = mockFacetHelper.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
+        extensions[0] = DeployMockFacet.makeCut(mockFacet, IDiamond.FacetCutAction.Add);
 
         vm.prank(deployer);
         IDiamondCut(address(implementation)).diamondCut(


### PR DESCRIPTION
Unified deployment logic under `DeployFacet` and corresponding libraries to replace redundant facet-specific deployer contracts. This improves reusability, maintainability, and consistency in contract initialization and function selector management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Consolidated and streamlined the deployment workflow by centralizing facet deployment logic and reducing redundant code.
  - Transitioned key components to library-based implementations to improve maintainability.

- **Tests**
  - Updated test suites to simplify deployments by eliminating unnecessary helper instances and directly using static methods.

- **Chores**
  - Made minor code formatting adjustments and updated module references for a cleaner, more coherent project structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->