### PR TITLE
chore: update Solidity version to 0.8.19 for compatibility

### DIFF
--- a/scripts/common/DeployHelpers.s.sol
+++ b/scripts/common/DeployHelpers.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/scripts/common/helpers/FacetHelper.s.sol
+++ b/scripts/common/helpers/FacetHelper.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 import {IDiamond} from "../../../src/IDiamond.sol";
 

--- a/scripts/deployments/diamonds/DeployDiamond.s.sol
+++ b/scripts/deployments/diamonds/DeployDiamond.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {Diamond, IDiamond} from "src/Diamond.sol";

--- a/scripts/deployments/facets/DeployDiamondCut.s.sol
+++ b/scripts/deployments/facets/DeployDiamondCut.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployDiamondLoupe.s.sol
+++ b/scripts/deployments/facets/DeployDiamondLoupe.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployEIP712Facet.s.sol
+++ b/scripts/deployments/facets/DeployEIP712Facet.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployIntrospection.s.sol
+++ b/scripts/deployments/facets/DeployIntrospection.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployManagedProxy.s.sol
+++ b/scripts/deployments/facets/DeployManagedProxy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployMultiInit.s.sol
+++ b/scripts/deployments/facets/DeployMultiInit.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //libraries
 import {DeployLib} from "../../common/DeployLib.sol";

--- a/scripts/deployments/facets/DeployOwnable.s.sol
+++ b/scripts/deployments/facets/DeployOwnable.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployOwnablePending.s.sol
+++ b/scripts/deployments/facets/DeployOwnablePending.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployPausable.s.sol
+++ b/scripts/deployments/facets/DeployPausable.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployTokenOwnable.s.sol
+++ b/scripts/deployments/facets/DeployTokenOwnable.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/facets/DeployTokenPausable.s.sol
+++ b/scripts/deployments/facets/DeployTokenPausable.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/mocks/DeployMockERC20Permit.s.sol
+++ b/scripts/deployments/mocks/DeployMockERC20Permit.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/mocks/DeployMockERC6909.s.sol
+++ b/scripts/deployments/mocks/DeployMockERC6909.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/mocks/DeployMockERC721.sol
+++ b/scripts/deployments/mocks/DeployMockERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/scripts/deployments/utils/DeployProxyManager.s.sol
+++ b/scripts/deployments/utils/DeployProxyManager.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 //interfaces
 import {IDiamond} from "../../../src/IDiamond.sol";

--- a/src/Diamond.sol
+++ b/src/Diamond.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "./IDiamond.sol";

--- a/src/IDiamond.sol
+++ b/src/IDiamond.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/Facet.sol
+++ b/src/facets/Facet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/cut/DiamondCutBase.sol
+++ b/src/facets/cut/DiamondCutBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "../../IDiamond.sol";

--- a/src/facets/cut/DiamondCutFacet.sol
+++ b/src/facets/cut/DiamondCutFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "../../IDiamond.sol";

--- a/src/facets/cut/DiamondCutStorage.sol
+++ b/src/facets/cut/DiamondCutStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/cut/IDiamondCut.sol
+++ b/src/facets/cut/IDiamondCut.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "../../IDiamond.sol";

--- a/src/facets/initializable/InitializableStorage.sol
+++ b/src/facets/initializable/InitializableStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/introspection/IIntrospectionBase.sol
+++ b/src/facets/introspection/IIntrospectionBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/introspection/IntrospectionBase.sol
+++ b/src/facets/introspection/IntrospectionBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IIntrospectionBase} from "./IIntrospectionBase.sol";

--- a/src/facets/introspection/IntrospectionFacet.sol
+++ b/src/facets/introspection/IntrospectionFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/src/facets/introspection/IntrospectionStorage.sol
+++ b/src/facets/introspection/IntrospectionStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/loupe/DiamondLoupeBase.sol
+++ b/src/facets/loupe/DiamondLoupeBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamondLoupeBase} from "./IDiamondLoupe.sol";

--- a/src/facets/loupe/DiamondLoupeFacet.sol
+++ b/src/facets/loupe/DiamondLoupeFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamondLoupe} from "./IDiamondLoupe.sol";

--- a/src/facets/loupe/IDiamondLoupe.sol
+++ b/src/facets/loupe/IDiamondLoupe.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/ownable/IERC173.sol
+++ b/src/facets/ownable/IERC173.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/ownable/OwnableBase.sol
+++ b/src/facets/ownable/OwnableBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IOwnableBase} from "./IERC173.sol";

--- a/src/facets/ownable/OwnableFacet.sol
+++ b/src/facets/ownable/OwnableFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC173} from "./IERC173.sol";

--- a/src/facets/ownable/OwnableStorage.sol
+++ b/src/facets/ownable/OwnableStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/ownable/pending/IOwnablePending.sol
+++ b/src/facets/ownable/pending/IOwnablePending.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/ownable/pending/OwnablePendingBase.sol
+++ b/src/facets/ownable/pending/OwnablePendingBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IOwnablePendingBase} from "./IOwnablePending.sol";

--- a/src/facets/ownable/pending/OwnablePendingFacet.sol
+++ b/src/facets/ownable/pending/OwnablePendingFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IOwnablePending} from "./IOwnablePending.sol";

--- a/src/facets/ownable/pending/OwnablePendingStorage.sol
+++ b/src/facets/ownable/pending/OwnablePendingStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/ownable/token/ITokenOwnable.sol
+++ b/src/facets/ownable/token/ITokenOwnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/ownable/token/TokenOwnableBase.sol
+++ b/src/facets/ownable/token/TokenOwnableBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {ITokenOwnableBase} from "./ITokenOwnable.sol";

--- a/src/facets/ownable/token/TokenOwnableFacet.sol
+++ b/src/facets/ownable/token/TokenOwnableFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC173} from "../IERC173.sol";

--- a/src/facets/ownable/token/TokenOwnableStorage.sol
+++ b/src/facets/ownable/token/TokenOwnableStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/pausable/IPausable.sol
+++ b/src/facets/pausable/IPausable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/pausable/PausableBase.sol
+++ b/src/facets/pausable/PausableBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IPausableBase} from "./IPausable.sol";

--- a/src/facets/pausable/PausableFacet.sol
+++ b/src/facets/pausable/PausableFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IPausable} from "./IPausable.sol";

--- a/src/facets/pausable/PausableStorage.sol
+++ b/src/facets/pausable/PausableStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/pausable/token/TokenPausableFacet.sol
+++ b/src/facets/pausable/token/TokenPausableFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IPausable} from "../IPausable.sol";

--- a/src/facets/reentrancy/IReentrancyGuard.sol
+++ b/src/facets/reentrancy/IReentrancyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/reentrancy/ReentrancyGuard.sol
+++ b/src/facets/reentrancy/ReentrancyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/reentrancy/ReentrancyGuardStorage.sol
+++ b/src/facets/reentrancy/ReentrancyGuardStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/token/ERC20/ERC20.sol
+++ b/src/facets/token/ERC20/ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/facets/token/ERC20/ERC20Storage.sol
+++ b/src/facets/token/ERC20/ERC20Storage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 import {MinimalERC20Storage} from "../../../primitive/ERC20.sol";
 

--- a/src/facets/token/ERC20/permit/ERC20PermitBase.sol
+++ b/src/facets/token/ERC20/permit/ERC20PermitBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC20PermitBase} from "./IERC20PermitBase.sol";

--- a/src/facets/token/ERC20/permit/IERC20PermitBase.sol
+++ b/src/facets/token/ERC20/permit/IERC20PermitBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/token/ERC6909/ERC6909.sol
+++ b/src/facets/token/ERC6909/ERC6909.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {

--- a/src/facets/token/ERC6909/ERC6909Storage.sol
+++ b/src/facets/token/ERC6909/ERC6909Storage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 import {MinimalERC6909Storage} from "../../../primitive/ERC6909.sol";
 

--- a/src/facets/token/ERC721/ERC721.sol
+++ b/src/facets/token/ERC721/ERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/facets/token/ERC721/ERC721Storage.sol
+++ b/src/facets/token/ERC721/ERC721Storage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/initializers/MultiInit.sol
+++ b/src/initializers/MultiInit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/primitive/ERC721.sol
+++ b/src/primitive/ERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";

--- a/src/proxy/IProxy.sol
+++ b/src/proxy/IProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/proxy/Proxy.sol
+++ b/src/proxy/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IProxy} from "./IProxy.sol";

--- a/src/proxy/managed/IManagedProxy.sol
+++ b/src/proxy/managed/IManagedProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/proxy/managed/ManagedProxyBase.sol
+++ b/src/proxy/managed/ManagedProxyBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IManagedProxyBase} from "./IManagedProxy.sol";

--- a/src/proxy/managed/ManagedProxyFacet.sol
+++ b/src/proxy/managed/ManagedProxyFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IManagedProxy} from "./IManagedProxy.sol";

--- a/src/proxy/managed/ManagedProxyStorage.sol
+++ b/src/proxy/managed/ManagedProxyStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/proxy/manager/IProxyManager.sol
+++ b/src/proxy/manager/IProxyManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/proxy/manager/ProxyManager.sol
+++ b/src/proxy/manager/ProxyManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IProxyManager} from "./IProxyManager.sol";

--- a/src/proxy/manager/ProxyManagerBase.sol
+++ b/src/proxy/manager/ProxyManagerBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamondLoupe} from "../../facets/loupe/IDiamondLoupe.sol";

--- a/src/proxy/manager/ProxyManagerStorage.sol
+++ b/src/proxy/manager/ProxyManagerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/utils/Nonces.sol
+++ b/src/utils/Nonces.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/utils/cryptography/EIP712Base.sol
+++ b/src/utils/cryptography/EIP712Base.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/src/utils/cryptography/EIP712Facet.sol
+++ b/src/utils/cryptography/EIP712Facet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC5267} from "@openzeppelin/contracts/interfaces/IERC5267.sol";

--- a/test/facets/cut/DiamondCut.t.sol
+++ b/test/facets/cut/DiamondCut.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/facets/initializable/Initializable.t.sol
+++ b/test/facets/initializable/Initializable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/test/facets/introspection/Introspection.t.sol
+++ b/test/facets/introspection/Introspection.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/facets/loupe/DiamondLoupe.t.sol
+++ b/test/facets/loupe/DiamondLoupe.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/facets/ownable/Ownable.t.sol
+++ b/test/facets/ownable/Ownable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/facets/ownable/pending/OwnablePending.t.sol
+++ b/test/facets/ownable/pending/OwnablePending.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/facets/ownable/token/TokenOwnable.t.sol
+++ b/test/facets/ownable/token/TokenOwnable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/facets/pausable/Pausable.t.sol
+++ b/test/facets/pausable/Pausable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {DeployDiamond} from "scripts/deployments/diamonds/DeployDiamond.s.sol";

--- a/test/facets/pausable/TokenPausable.t.sol
+++ b/test/facets/pausable/TokenPausable.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {DeployDiamond} from "scripts/deployments/diamonds/DeployDiamond.s.sol";

--- a/test/facets/signature/EIP712.t.sol
+++ b/test/facets/signature/EIP712.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/facets/signature/EIP712Utils.sol
+++ b/test/facets/signature/EIP712Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/initializers/MultiInit.t.sol
+++ b/test/initializers/MultiInit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/mocks/MockERC20Permit.sol
+++ b/test/mocks/MockERC20Permit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/test/mocks/MockERC6909.sol
+++ b/test/mocks/MockERC6909.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 import {ERC6909} from "src/facets/token/ERC6909/ERC6909.sol";
 

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/test/mocks/MockFacet.sol
+++ b/test/mocks/MockFacet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 import {IDiamond} from "../../src/IDiamond.sol";

--- a/test/mocks/MockProxyInstance.sol
+++ b/test/mocks/MockProxyInstance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/test/mocks/MockToken.sol
+++ b/test/mocks/MockToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // interfaces
 

--- a/test/proxy/ProxyManager.t.sol
+++ b/test/proxy/ProxyManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity ^0.8.19;
 
 // utils
 import {TestUtils} from "test/TestUtils.sol";


### PR DESCRIPTION
Updated the pragma directive in all Solidity files to use version 0.8.19. This ensures greater compatibility, improvements, and consistency across the codebase. No functional changes were introduced.