### PR TITLE
chore: update dependencies and license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Package](https://img.shields.io/npm/v/@towns-protocol/diamond.svg)](https://www.npmjs.org/package/@towns-protocol/diamond)
 [![CI Status](https://github.com/towns-protocol/diamond/workflows/CI/badge.svg)](https://github.com/towns-protocol/diamond/actions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/towns-protocol/diamond/blob/main/LICENSE)
 [![Solidity Version](https://img.shields.io/badge/solidity-^0.8.29-lightgrey)](https://solidity.readthedocs.io/en/v0.8.29/)
 
 A comprehensive toolkit for building modular smart contracts with the [EIP-2535 Diamond Standard](https://eips.ethereum.org/EIPS/eip-2535). This package provides both the core Diamond contracts and optimized building blocks to create efficient, upgradeable systems.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@towns-protocol/diamond",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A comprehensive toolkit for building modular smart contracts with the EIP-2535 Diamond Standard, including core contracts and optimized building blocks",
   "main": "index.js",
   "repository": {
@@ -38,10 +38,10 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.3.0",
+    "@openzeppelin/contracts": "^5.4.0",
     "@prb/test": "^0.6.4",
-    "forge-std": "github:foundry-rs/forge-std#v1.9.7",
-    "solady": "^0.1.14"
+    "forge-std": "github:foundry-rs/forge-std#v1.10.0",
+    "solady": "^0.1.24"
   },
   "devDependencies": {
     "husky": "^9.0.6"


### PR DESCRIPTION
- Bumped `@openzeppelin/contracts`, `forge-std`, and `solady` dependencies to latest versions.
- Updated MIT license badge link in `README.md` to direct to the project's LICENSE file.
- Incremented version to 0.6.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README license badge to link directly to the repository’s LICENSE file for clearer attribution. No functional changes.

* **Chores**
  * Bumped version to 0.6.2.
  * Updated dependencies to align with latest ecosystem releases:
    - OpenZeppelin Contracts to ^5.4.0
    - forge-std to v1.10.0
    - solady to ^0.1.24
  * These updates improve compatibility and maintenance without impacting existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->