### PR TITLE
chore: allow publishing of identical npm package versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,6 +44,6 @@ jobs:
           if [ -n "$VERSION" ]; then
             # Remove 'v' prefix if present
             VERSION=$(echo "$VERSION" | sed 's/^v//')
-            npm version "$VERSION" --no-git-tag-version
+            npm version "$VERSION" --no-git-tag-version --allow-same-version
           fi
           npm publish --access public


### PR DESCRIPTION
Added `--allow-same-version` flag to `npm version` command in the GitHub Actions workflow, enabling publishing of packages with the same version number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to permit publishing when the specified version matches the current package version, preventing unnecessary failures while continuing to avoid creating git tags. This improves reliability of our publish process. All existing behavior, including version sanitization and publication steps, remains the same. This change streamlines CI runs for releases with unchanged versions and reduces operational noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->