### PR TITLE
chore: update gas limit constant and configure linting rules

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,6 +21,10 @@ number_underscore = "thousands"
 quote_style = "double"
 sort_imports = true
 
+[lint]
+severity = ["high", "med", "low", "gas"]
+exclude_lints = ["asm-keccak256", "erc20-unchecked-transfer", "incorrect-shift"]
+
 [profile.ci.fuzz]
 runs = 65536
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@towns-protocol/diamond",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A comprehensive toolkit for building modular smart contracts with the EIP-2535 Diamond Standard, including core contracts and optimized building blocks",
   "main": "index.js",
   "repository": {

--- a/scripts/common/DeployFacet.s.sol
+++ b/scripts/common/DeployFacet.s.sol
@@ -16,7 +16,7 @@ contract DeployFacet is DeployBase {
     using LibString for *;
 
     /// @dev Constants for gas estimation
-    uint256 internal constant BLOCK_GAS_LIMIT = 30_000_000;
+    uint256 internal constant PER_TRANSACTION_GAS_LIMIT = 1 << 24; // gas limit per EIP-7825
     uint256 internal constant BASE_TX_COST = 21_000;
     uint256 internal constant CONTRACT_CREATION_COST = 32_000;
     uint256 internal constant STORAGE_VARIABLE_COST = 22_100;
@@ -101,13 +101,13 @@ contract DeployFacet is DeployBase {
         // estimate gas cost for this deployment
         batchGasEstimate += estimateDeploymentGas(bytecode);
 
-        // check if adding this contract would exceed block gas limit
-        if (batchGasEstimate > BLOCK_GAS_LIMIT) {
+        // check if adding this contract would exceed per-transaction gas limit
+        if (batchGasEstimate > PER_TRANSACTION_GAS_LIMIT) {
             warn(
                 string.concat(
                     "DeployFacet: Adding contract ",
                     name,
-                    " may exceed block gas limit 30_000_000. Deploy current batch first."
+                    " may exceed per-transaction gas limit 16,777,216. Deploy current batch first."
                 )
             );
         }


### PR DESCRIPTION
- Renamed and updated `BLOCK_GAS_LIMIT` to `PER_TRANSACTION_GAS_LIMIT` in line with EIP-7825.
- Added granular linting configuration in `foundry.toml`, including severity levels and exclusions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated deployment gas checks to use a per-transaction limit (16,777,216) with clearer warning messages, aligning with the latest guidance for more accurate batch deployments.

- Chores
  - Added lint configuration with severity levels (high, med, low, gas) and excluded rules for more targeted linting.
  - Bumped version to 0.6.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->