### PR TITLE
chore: bump version to 0.7.0 and update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@towns-protocol/diamond",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "A comprehensive toolkit for building modular smart contracts with the EIP-2535 Diamond Standard, including core contracts and optimized building blocks",
   "main": "index.js",
   "repository": {
@@ -40,8 +40,8 @@
   "dependencies": {
     "@openzeppelin/contracts": "^5.4.0",
     "@prb/test": "^0.6.4",
-    "forge-std": "github:foundry-rs/forge-std#v1.10.0",
-    "solady": "^0.1.24"
+    "forge-std": "github:foundry-rs/forge-std#v1.12.0",
+    "solady": "^0.1.26"
   },
   "devDependencies": {
     "husky": "^9.0.6"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,4 +70,4 @@ The script uses a comprehensive gas estimation model that considers:
 - Deployed bytecode costs (200 gas per byte)
 - Storage variable costs (22,100 gas)
 
-This ensures accurate gas estimates for both single and batch deployments while providing warnings when approaching block gas limits.
+This ensures accurate gas estimates for both single and batch deployments. Batches are automatically split when approaching per-transaction gas limits, and contracts exceeding the limit are blocked at queue time.


### PR DESCRIPTION
- forge-std: v1.10.0 → v1.12.0
- solady: 0.1.24 → 0.1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.7.0 with updated dependencies.

* **Documentation**
  * Clarified gas estimation behavior: system automatically splits batches when approaching per-transaction gas limits and blocks contracts exceeding the limit at queue time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->